### PR TITLE
Update README.txt with new link to download

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -4,7 +4,7 @@ Workspace and project files are in MSVC 6.0 format.
 
 Ide and Debugger require MFC which is included with MSVC 6.0, but not with later free/express versions of MSVC.
 
-You can grab the prebuilt free version of blitz3d from www.blitzbasic.com.
+You can grab the prebuilt free version of blitz3d from https://blitzresearch.itch.io/blitz3d.
 
 Steps to build:
 


### PR DESCRIPTION
blitzbasic.com has been down for a long time, and the prebuilt version of Blitz3D is now currently hosted at itch.io. I'm not sure if this repo is still looked at by the owner, it's been a long time since there have been any updates, but it's worth a shot.